### PR TITLE
FIX: fix documentation links

### DIFF
--- a/content/pages/docs.md
+++ b/content/pages/docs.md
@@ -6,8 +6,13 @@ title: Documentation
 
 The wradlib project is documented via sphinx using the sphinx-rtd-theme. It is available on [github](http://wradlib.github.io/wradlib-docs).
 
-Within the documentation an [extensive tutorial section](http://wradlib.github.io/wradlib-docs/tutorials.html) covering many real world use cases is available.
+Within the documentation an [extensive tutorial section](http://wradlib.github.io/wradlib-docs/latest/tutorials.html) covering many real world use cases is available.
 
-For developers there is a [documentation of the API](http://wradlib.github.io/wradlib-docs/reference.html).
+For developers there is a [documentation of the API](http://wradlib.github.io/wradlib-docs/latest/reference.html).
 
-[Background literature](http://wradlib.github.io/wradlib-docs/zreferences.html) used for developement of wradlib is also available
+[Background literature](http://wradlib.github.io/wradlib-docs/latest/zreferences.html) used for developement of wradlib is also available
+
+There is also documentation archive of older releases:
+
+* [0.7.0](http://wradlib.github.io/wradlib-docs/0.7.0)
+* [0.6.0](http://wradlib.github.io/wradlib-docs/0.6.0)


### PR DESCRIPTION
points docu links to the correct location (latest) which is necessary for the new doc scwitching
