### PR TITLE
Fix links

### DIFF
--- a/content/pages/docs.md
+++ b/content/pages/docs.md
@@ -4,15 +4,10 @@ title: Documentation
 
 ## wradlib documentation
 
-The wradlib project is documented via sphinx using the sphinx-rtd-theme. It is available on [github](http://wradlib.github.io/wradlib-docs).
+The wradlib project is documented via sphinx using the sphinx-rtd-theme. It is available [here](http://docs.wradlib.org).
 
-Within the documentation an [extensive tutorial section](http://wradlib.github.io/wradlib-docs/latest/tutorials.html) covering many real world use cases is available.
+Within the documentation an [extensive tutorial section](http://docs.wradlib.org/en/latest/notebooks.html) covering many real world use cases is available.
 
-For developers there is a [documentation of the API](http://wradlib.github.io/wradlib-docs/latest/reference.html).
+For developers there is a [documentation of the API](http://docs.wradlib.org/en/latest/reference.html).
 
-[Background literature](http://wradlib.github.io/wradlib-docs/latest/zreferences.html) used for developement of wradlib is also available
-
-There is also documentation archive of older releases:
-
-* [0.7.0](http://wradlib.github.io/wradlib-docs/0.7.0)
-* [0.6.0](http://wradlib.github.io/wradlib-docs/0.6.0)
+[Background literature](http://docs.wradlib.org/en/latest/zreferences.html) used for developement of wradlib is also available

--- a/content/posts/introducing-wradlib-jupyter-notebooks.md
+++ b/content/posts/introducing-wradlib-jupyter-notebooks.md
@@ -14,9 +14,9 @@ Still, for users who just want to run examples as plain Python scripts, we will 
 
 For getting an idea about jupyter notebooks within wradlib have a look at these three (rendered) notebooks:
 
-- [RADOLAN - Radar Products from German Weather Service](http://wradlib.org/wradlib-docs/latest/notebooks/radolan.html),
-- [Beam Blockage Calculation using DEM](http://wradlib.org/wradlib-docs/latest/notebooks/beamblockage/wradlib_beamblock.html) and
-- [Plot Additional Data](http://wradlib.org/wradlib-docs/latest/notebooks/visualisation/wradlib_overlay.html)
+- [RADOLAN - Radar Products from German Weather Service](http://docs.wradlib.org/en/latest/notebooks/radolan.html),
+- [Beam Blockage Calculation using DEM](http://docs.wradlib.org/en/latest/notebooks/beamblockage/wradlib_beamblock.html) and
+- [Plot Additional Data](http://docs.wradlib.org/en/latest/notebooks/visualisation/wradlib_overlay.html)
 
 We are currently in the process of transition. Successively, we will migrate all tutorials and examples.
 

--- a/content/posts/wradlib_release_0_11_0.md
+++ b/content/posts/wradlib_release_0_11_0.md
@@ -7,9 +7,9 @@ Tags: releases, github, python2, python3
 
 We are happy to announce the release of wradlib 0.11.0.
 
-It introduces our first shot at reading IRIS (Sigmet) data - a feature that has been requested by quite a number users. Learn more about io.read_iris, and see it at work [here](http://wradlib.org/wradlib-docs/latest/notebooks/fileio/wradlib_radar_formats.html#Vaisala-Sigmet-IRIS). We are looking forward to your feedback!
+It introduces our first shot at reading IRIS (Sigmet) data - a feature that has been requested by quite a number users. Learn more about io.read_iris, and see it at work [here](http://docs.wradlib.org/en/latest/notebooks/fileio/wradlib_radar_formats.html#Vaisala-Sigmet-IRIS). We are looking forward to your feedback!
 
 In addition, we redesigned the `io` and `georef` modules. As a user, you will hopefully not notice. As a developer, you will hopefully welcome a higher level of (sub-)modularization.
 
-For more details on the new release, please visit our [release notes](http://wradlib.org/wradlib-docs/0.11.0/release_notes.html).
+For more details on the new release, please visit our [release notes](http://docs.wradlib.org/en/latest/release_notes.html).
 

--- a/content/posts/wradlib_release_0_8_0.md
+++ b/content/posts/wradlib_release_0_8_0.md
@@ -19,7 +19,7 @@ wradlib 0.8.0 is the first release that follows upon this major transition. As a
 You can keep on installing new wradlib releases with the `pip install` mechanism. Cloning the bleeding edge code will require to install a `git` client and point it to [https://github.com/wradlib/wradlib](https://github.com/wradlib/wradlib). Developers are cordially invited to fork from that repository and share their developments via Pull Requests.
 
 Apart from these changes, wradlib 0.8.0 includes a couple of improvements particularly related to the 
-[zonalstats module](http://wradlib.org/wradlib-docs/latest/zonalstats.html). Please expect further changes to that module in the future, making it more generic and more convenient.
+[zonalstats module](http://docs.wradlib.org/en/latest/zonalstats.html). Please expect further changes to that module in the future, making it more generic and more convenient.
 
 We are now using Travis CI to continuously scrutinize the integrity of our codebase. Still, the transition might imply a 
 couple issues that we have not yet identified. Please bear with us, and do not hesitate to report issues [here](https://github.com/wradlib/wradlib/issues),

--- a/content/posts/wradlib_release_0_9_0.md
+++ b/content/posts/wradlib_release_0_9_0.md
@@ -14,15 +14,15 @@ more convenient and interactive. We hope you'll agree!
 ### Interactive examples with jupyter notebooks 
 
 As a consequence, the previous doc sections "Tutorials" and "Recipes" have been replaced by one single 
-section [Tutorials and Examples](http://wradlib.org/wradlib-docs/latest/notebooks.html). 
+section [Tutorials and Examples](http://docs.wradlib.org/en/latest/notebooks.html).
 The pages in that section were automatically built from jupyter 
 (IPython) notebooks. These notebooks are distributed with the [new release](https://pypi.python.org/pypi/wradlib), 
 and you can use them to interactively browse through our tutorials and examples. You can always download the latest notebooks 
 from the [wradlib repository](https://github.com/wradlib/wradlib/tree/master/notebooks).
 
 For those who do not know, yet, how to handle jupyter notebooks, we prepared a 
-[quick tutorial](http://wradlib.org/wradlib-docs/latest/jupyter.html). We also added a 
-brief (and certainly incomplete) [intro to Python](http://wradlib.org/wradlib-docs/latest/notebooks/learnpython.html) 
+[quick tutorial](http://docs.wradlib.org/en/latest/jupyter.html). We also added a
+brief (and certainly incomplete) [intro to Python](http://docs.wradlib.org/en/latest/notebooks/learnpython.html)
 for those who would like to have some entry point to that language. This intro will certainly be further developed 
 in the future.
 
@@ -32,7 +32,7 @@ In case you don't want to use notebooks: straight Python scripts are distributed
 
 We moved all the example data from the main
 [wradlib repository](https://github.com/wradlib/wradlib/) to a new [data repository](https://github.com/wradlib/wradlib-data).
-In order to run the notebooks on your computer, you need to download the example data archive yourself, and extract it to any directory on your computer. Then you need to create an environment variable pointing to that directory. After that, the example notebooks will automagically pull the required example data from that directory. See [here](http://wradlib.org/wradlib-docs/latest/jupyter.html#how-can-i-get-the-example-data) for more detailed guidance on the process.   
+In order to run the notebooks on your computer, you need to download the example data archive yourself, and extract it to any directory on your computer. Then you need to create an environment variable pointing to that directory. After that, the example notebooks will automagically pull the required example data from that directory. See [here](http://docs.wradlib.org/en/latest/jupyter.html#how-can-i-get-the-example-data) for more detailed guidance on the process.
 
 ### Further changes in wradlib 0.9.0 
 
@@ -62,7 +62,7 @@ $ conda install wradlib
 You can drop the first line if you already added the conda-forge channel.
 
 For more details, or if you do not use Anaconda or conda, see our
-[installation instructions](http://wradlib.org/wradlib-docs/latest/gettingstarted.html). 
+[installation instructions](http://docs.wradlib.org/en/latest/gettingstarted.html).
 
 In case you lost track of your Anaconda environments, you can use
 


### PR DESCRIPTION
link to new docs.wradlib.org instead of old wradlib.org/wradlib-docs